### PR TITLE
Execute sam from local site packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "samwich-cli"
-version = "0.12.0"
+version = "0.13.0"
 description = "A CLI tool to streamline AWS SAM deployments for Python Lambda functions by managing dependencies, executing sam build, and maintaining consistent folder structures."
 license = "MIT"
 license-files = ["LICENSE"]

--- a/samwich_cli/sam_utils.py
+++ b/samwich_cli/sam_utils.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import pathlib
-import subprocess
+import sys
 from typing import Final
 
 import click
+from samcli.cli.main import cli
 from samcli.commands._utils import constants
 from samcli.commands.build import build_context
 from samcli.lib.providers import provider
@@ -16,7 +17,10 @@ SAM_BUILD_DIR: Final[pathlib.Path] = pathlib.Path.cwd() / constants.DEFAULT_BUIL
 
 def sam_build(sam_args: tuple[str, ...], debug: bool) -> None:
     """Run the SAM build command."""
-    args = ("sam", "build", *sam_args)
+
+    original_args = sys.argv.copy()
+
+    args = ["sam", "build", *sam_args]
     if debug:
         click.echo()
         click.echo()
@@ -25,12 +29,16 @@ def sam_build(sam_args: tuple[str, ...], debug: bool) -> None:
     click.echo()
     click.echo(f"+ {' '.join(args)}")
     click.echo()
-    subprocess.check_call(args, shell=False)
-    click.echo()
-    click.secho("=" * 25, fg="magenta")
-    click.secho("End SAM build", fg="magenta")
-    click.echo()
-    click.echo()
+    try:
+        sys.argv = args
+        cli(prog_name="sam")
+    finally:
+        sys.argv = original_args
+        click.echo()
+        click.secho("=" * 25, fg="magenta")
+        click.secho("End SAM build", fg="magenta")
+        click.echo()
+        click.echo()
 
 
 def get_build_resources(

--- a/uv.lock
+++ b/uv.lock
@@ -1572,7 +1572,7 @@ wheels = [
 
 [[package]]
 name = "samwich-cli"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "aws-sam-cli" },


### PR DESCRIPTION
This pull request updates the `samwich-cli` project to version 0.13.0 and refactors the `sam_build` function to use the AWS SAM CLI programmatically instead of invoking it as a subprocess. These changes enhance maintainability and align the tool with best practices for CLI integration.